### PR TITLE
[HOTFIX] Typescript: Always use workspace version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
Add setting to use the workspace version of TypeScript for the application instead of the global version